### PR TITLE
Added BEService_x64.exe to generated files

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -13,6 +13,7 @@ namespace Seion.GenuineClient
 
             var rootDir = $@"{Environment.CurrentDirectory}\GenuineClient";
             CreateEmptyTextFile($@"{rootDir}\BattlEye\BEClient_x64.dll");
+            CreateEmptyTextFile($@"{rootDir}\BattlEye\BEService_x64.exe");
             CreateEmptyTextFile($@"{rootDir}\ConsistencyInfo");
             CreateEmptyTextFile($@"{rootDir}\Uninstall.exe");
             CreateEmptyTextFile($@"{rootDir}\UnityCrashHandler64.exe");


### PR DESCRIPTION
Without this file validation fails.

Without
![Without](https://github.com/nexus4880/genuineclient/assets/38168516/1ec97976-49b9-45a6-8025-2997dee7d16b)

With
![With](https://github.com/nexus4880/genuineclient/assets/38168516/21bb7a59-5b95-4a95-8795-8bcc0484b711)
